### PR TITLE
Add output schema definition for Actor

### DIFF
--- a/.actor/actor.json
+++ b/.actor/actor.json
@@ -5,5 +5,6 @@
 	},
 	"name": "google-oauth2",
 	"version": "0.1",
-	"buildTag": "latest"
+	"buildTag": "latest",
+	"output": "./output_schema.json"
 }

--- a/.actor/output_schema.json
+++ b/.actor/output_schema.json
@@ -8,12 +8,6 @@
             "title": "Processed data",
             "description": "Data read from the spreadsheet, available when the Actor runs in the `read` mode.",
             "template": "{{links.apiDefaultKeyValueStoreUrl}}/records/OUTPUT"
-        },
-        "backup": {
-            "type": "string",
-            "title": "Spreadsheet backup",
-            "description": "Snapshot of the spreadsheet rows taken before the update, available when `createBackup` is enabled.",
-            "template": "{{links.apiDefaultKeyValueStoreUrl}}/records/backup"
         }
     }
 }

--- a/.actor/output_schema.json
+++ b/.actor/output_schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://apify-projects.github.io/actor-json-schemas/output.json?v=0.3",
+    "actorOutputSchemaVersion": 1,
+    "title": "Output schema of the Actor",
+    "properties": {
+        "processedData": {
+            "type": "string",
+            "title": "Processed data",
+            "description": "Data read from the spreadsheet, available when the Actor runs in the `read` mode.",
+            "template": "{{links.apiDefaultKeyValueStoreUrl}}/records/OUTPUT"
+        },
+        "backup": {
+            "type": "string",
+            "title": "Spreadsheet backup",
+            "description": "Snapshot of the spreadsheet rows taken before the update, available when `createBackup` is enabled.",
+            "template": "{{links.apiDefaultKeyValueStoreUrl}}/records/backup"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds an output schema definition for the google-oauth2 Actor and registers it in the Actor configuration.

## Key Changes
- **Created `.actor/output_schema.json`**: New output schema file that defines the structure of data produced by the Actor
  - Defines a `processedData` property as a string type
  - Documents that this output is available when the Actor runs in `read` mode
  - Includes a template reference to the default key-value store output location
  - Uses the Apify output schema specification (v0.3)

- **Updated `.actor/actor.json`**: Added reference to the output schema
  - Added `"output": "./output_schema.json"` configuration to point to the new schema file

## Implementation Details
The output schema follows the Apify Actor JSON schema standard and provides metadata about the Actor's output structure, enabling better integration with the Apify platform and improved documentation of the Actor's capabilities.

https://claude.ai/code/session_01PcvK9V7n3v2WvVC6svJj9W